### PR TITLE
update Gari token to community-validated in Panora Aptos Token List

### DIFF
--- a/submit-token-request.ts
+++ b/submit-token-request.ts
@@ -1,3 +1,22 @@
 import { SubmitTokenRequestInfo } from "types"
 
-const requestList: SubmitTokenRequestInfo[] = []
+const requestList: SubmitTokenRequestInfo[] = [
+    {
+    "chainId": 1,
+    "tokenAddress": "0x4def3d3dee27308886f0a3611dd161ce34f977a9a5de4e80b237225923492a2a::coin::T",
+    "faAddress": "0xb81588af2f7d291e8e57f673ec74d4a38f0654633ad6bbeb1cfd4bb0550ae0df",
+    "name": "Gari",
+    "symbol": "GARI",
+    "decimals": 8,
+    "bridge": "Wormhole",
+    "panoraSymbol": "whGARI",
+    "logoUrl": "https://raw.githubusercontent.com/PanoraExchange/Aptos-Tokens/main/logos/GARI.svg",
+    "websiteUrl": "https://gari.network",
+    "category": "Bridged",
+    "isInPanoraTokenList": true,
+    "isBanned": false,
+    "panoraOrderIndex": 375,
+    "coinGeckoId": "gari-network",
+    "coinMarketCapId": 12969
+  }
+]


### PR DESCRIPTION
- Set `isInPanoraTokenList` to `true` for the Gari token, making it community-validated
- Ensures visibility as a verified token on the Panora platform